### PR TITLE
[修正] Dockerfileの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ WORKDIR /app
 
 # Prepare node_modules
 RUN npm install -g pnpm
-COPY . .
+COPY package.json pnpm-lock.yaml ./
+COPY .husky ./.husky
 
 ENV NODE_ENV=production
 RUN pnpm install --frozen-lockfile --production
+COPY . .
 
 RUN ./node_modules/next/dist/bin/next build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ WORKDIR /app
 
 # Prepare node_modules
 RUN npm install -g pnpm
-COPY package.json pnpm-lock.yaml ./
+COPY . .
 
 ENV NODE_ENV=production
 RUN pnpm install --frozen-lockfile --production
-COPY . .
 
 RUN ./node_modules/next/dist/bin/next build
 


### PR DESCRIPTION
#48 でprepare時に.husky/install.mjsを使用するようにした関係でビルドが落ちるようになったので修正
package.jsonとpnpm-lock.yamlのみコピーしていたが、そもそもnode_modulesは除外されていて分ける必要がなさそうなので最初にすべてコピーするように変更