### PR TITLE
Fix API endpoint

### DIFF
--- a/.github/workflows/deploy_prd.yaml
+++ b/.github/workflows/deploy_prd.yaml
@@ -8,7 +8,7 @@ env:
   ENV: prd
   AWS_REGION: ap-northeast-1
   AWS_ACCOUNT_ID: 905418376731
-  API_ENDPOINT: https://api.magi-sche.org
+  API_ENDPOINT: https://api.magi-sche.net
 
 jobs:
   build-and-push:
@@ -116,4 +116,3 @@ jobs:
           #   MEMORY: 1024
           #   CPU_ARCHITECTURE: ARM64
           CPU_ARCHITECTURE: X86_64
-          API_ENDPOINT: https://api.magi-sche.org


### PR DESCRIPTION
This pull request fixes the API endpoint in the environment variables to use the correct domain name "https://api.magi-sche.net" instead of "https://api.magi-sche.org".